### PR TITLE
board(スレッド一覧画面)のHTML/CSSを編集しました。

### DIFF
--- a/project/app/assets/stylesheets/posts/index.scss
+++ b/project/app/assets/stylesheets/posts/index.scss
@@ -2,3 +2,25 @@
   スレッド一覧画面のスタイル
   URL パス: /posts
 */
+
+body {
+  background-color: #f2f3f7;
+}
+
+.posts-index {
+  .top {
+    display: flex;
+    justify-content: center;
+  }
+
+  .heading-2 {
+    background: #efefef;
+  }
+
+  .thread-list {
+    color: #333333;
+    font-size: 14px;
+    background-color: #efefef;
+    text-align: left;
+  }
+}

--- a/project/app/views/posts/index.html.erb
+++ b/project/app/views/posts/index.html.erb
@@ -4,7 +4,20 @@
 %>
 
 <main class="posts-index">
-  <% 5.times do %>
-    <p><%= link_to "ほげほげスレ", "/posts/1" %></p>
-  <% end %>
+  <h1 class="top">
+    <%= link_to "G1ちゃんねる", "/" %>
+  </h1>
+
+  <h2>
+    <span class="heading-2">この掲示板の主なスレッド</span>
+  </h2>
+
+  <!--直近のスレッドを表示-->
+  <div class="thread-list">
+    <h4>直近のスレッド<h4>
+
+    <p class="thread-detail">
+      <%= link_to "スレッドタイトル1", "/posts/1" %>
+    </p>
+  </div>
 </main>


### PR DESCRIPTION
カンバンカード URL:https://www.notion.so/kotahashihama/HTML-CSS-4e186a7ac22d45f6a2d384f92da61fee

# 変更の目的・詳細

-board(スレッド一覧画面)のHTMLを5ちゃんねるに近づけるため

## 特にレビューしてほしいところ

-スレッド詳細画面のイメージが外れていないかの確認
-吉川さんのHTMLとの平仄


## 確認用 URL

-

## 参考資料 URL

-

# スクリーンショット
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/103372110/210073697-977a48cf-900c-419b-8796-5706c0bcf8ef.png">

