### PR TITLE
build(docker-compose.yml): いったん直に環境変数をアサイン

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: db
     image: mysql:8.0.31-oracle
     environment:
-      MYSQL_ROOT_PASSWORD: ${ENV_MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: password
       TZ: "Asia/Tokyo"
     ports:
       - "3306:3306"


### PR DESCRIPTION
カンバンカード URL:

# 変更の目的・詳細

- 本番環境が DB 接続できていないためお試し
- `heroku config:set` コマンドで同様に環境変数をセットし、そのあと `heroku restart` したり、 `README.md` を編集して空デプロイしてみたが改善されなかった

# スクリーンショット

|  最終的に以下を解決したい   | heroku 上で確認 | ターミナル上で値も確認 |
| --- | --- | --- |
|   <img width="1512" alt="スクリーンショット 2023-01-05 午後10 27 17" src="https://user-images.githubusercontent.com/33051893/210790725-a4ea1319-a27b-4261-a6fc-c3eeebf7eee6.png">  |    <img width="637" alt="スクリーンショット 2023-01-05 午後10 27 39" src="https://user-images.githubusercontent.com/33051893/210790793-1b0e5d47-c5fa-4fe0-8800-c9e32680a55c.png"> |  <img width="655" alt="スクリーンショット 2023-01-05 午後10 28 44" src="https://user-images.githubusercontent.com/33051893/210791091-95ddfeab-0074-4bef-876c-d02c3cdc07f3.png"> |
