### PR TITLE
本番でスレッド抜粋一覧が表示されていなかった問題を修正

### DIFF
--- a/project/app/controllers/posts_controller.rb
+++ b/project/app/controllers/posts_controller.rb
@@ -16,6 +16,7 @@ class PostsController < ApplicationController
     # show.html.erbに遷移するとこのメソッドを読みに来るので、対象post_idに紐づくcomment一覧を返す
     @comments = Comment.where(post_id: params[:id])
     @comment = Comment.new
+    @post_title = Post.find(params[:id]).title
   end
 
   def create

--- a/project/app/views/posts/index.html.erb
+++ b/project/app/views/posts/index.html.erb
@@ -40,48 +40,46 @@
 <!--編集中-->
 <%# 各スレッドごとにコメントを表示 %>
 <div class="posts">
-  <% for num in 1..@posts.size do %>
+  <% @posts.all.first(10).each do |post| %>
     <div style="border: solid 1px #000; border-radius: 12px; margin-bottom: 20px; padding: 8px">
-      <% @posts.where(id: num).first(10).each do |post| %>
-        <h2><%= post.title %></h2>
-        <div class="post">
-          <div class="meta">
-            <span class="number">
-              <%= post.comments.first.id %>
-            </span>
-            <span class="name">
-              <%= post.comments.first.contributor.empty? ? '名無しさん' : post.comments.first.contributor %>
-            </span>
-            <span class="date">
-              <%= post.comments.first.created_at.strftime('%Y/%m/%d %H:%M') %>
-            </span>
-          </div>
-          <div class="post-content">
-            <span class="escaped"><%= simple_format post.comments.first.comment %></p>
-          </div>
+      <h2><%= post.title %></h2>
+      <div class="post">
+        <div class="meta">
+          <span class="number">
+            <%= post.comments.first.id %>
+          </span>
+          <span class="name">
+            <%= post.comments.first.contributor.empty? ? '名無しさん' : post.comments.first.contributor %>
+          </span>
+          <span class="date">
+            <%= post.comments.first.created_at.strftime('%Y/%m/%d %H:%M') %>
+          </span>
         </div>
-        <% if @comments.where(post_id: num).size > 1 %>
-          <% @comments.where(post_id: num).drop(1).last(3).each do |comment| %>
-            <div class="post">
-              <div class="meta">
-                <span class="number">
-                  <%= comment.id %>
-                </span>
-                <span class="name">
-                  <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
-                </span>
-                <span class="date">
-                  <%= comment.created_at.strftime('%Y/%m/%d %H:%M') %>
-                </span>
-              </div>
-              <div class="post-content">
-                <span class="escaped"><%= simple_format comment.comment %></p>
-              </div>
+        <div class="post-content">
+          <span class="escaped"><%= simple_format post.comments.first.comment %></p>
+        </div>
+      </div>
+      <% if post.comments.size > 1 %>
+        <% post.comments.drop(1).last(3).each do |comment| %>
+          <div class="post">
+            <div class="meta">
+              <span class="number">
+                <%= comment.id %>
+              </span>
+              <span class="name">
+                <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
+              </span>
+              <span class="date">
+                <%= comment.created_at.strftime('%Y/%m/%d %H:%M') %>
+              </span>
             </div>
-          <% end %>
+            <div class="post-content">
+              <span class="escaped"><%= simple_format comment.comment %></p>
+            </div>
+          </div>
         <% end %>
-        <%= link_to "全部読む", post_path(post) %>
       <% end %>
+      <%= link_to "全部読む", post_path(post) %>
     </div>
   <% end %>
 </div>

--- a/project/app/views/posts/show.html.erb
+++ b/project/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <main class="posts-show">
-  <h1>スレッドタイトル</h1>
+  <h1><%= @post_title %></h1>
 
   <%# 投稿 %>
   <div class="posts">


### PR DESCRIPTION
カンバンカード URL: https://www.notion.so/kotahashihama/1cf9a9b73f0b4c16a1e9c083f934fafd

# 変更の目的・詳細

- `posts` テーブルの `id` が `1` からインクリメントされていくことを前提とした実装になっていたため、ローカルでは大丈夫でも本番で壊れていた
- ついでにスレッド詳細でスレッドタイトルが表示されていなかったため修正

# スクリーンショット

| スレッド詳細でスレッドタイトルを表示 |
| ---- |
| <img width="577" alt="スクリーンショット 2023-01-20 午前9 36 55" src="https://user-images.githubusercontent.com/33051893/213592944-56b77c72-d54b-43c1-b004-7564510c8e5d.png"> |
