### PR TITLE
ログインユーザーとして投稿できるよう実装

### DIFF
--- a/project/app/controllers/comments_controller.rb
+++ b/project/app/controllers/comments_controller.rb
@@ -3,6 +3,10 @@ class CommentsController < ApplicationController
     serial_id = Comment.where(post_id: params[:comment][:post_id]).count + 1
     processed_comment_params = comment_params
     processed_comment_params['serial_id'] = serial_id
+
+    # ユーザーのなりすましを防止
+    processed_comment_params['contributor'] = processed_comment_params['contributor'].tr('◆', '◇')
+
     @comment = Comment.create(processed_comment_params)
 
     redirect_to controller: :posts, action: :show, id: @comment.post_id
@@ -11,6 +15,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:contributor, :comment, :post_id)
+    params.require(:comment).permit(:contributor, :comment, :post_id, :user_id)
   end
 end

--- a/project/app/controllers/posts_controller.rb
+++ b/project/app/controllers/posts_controller.rb
@@ -10,6 +10,7 @@ class PostsController < ApplicationController
     # 追加分
     @comments = Comment.all
     @comment = Comment.new
+    @users = User.all
   end
 
   def show

--- a/project/app/controllers/posts_controller.rb
+++ b/project/app/controllers/posts_controller.rb
@@ -57,6 +57,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, comments_attributes: [:comment, :contributor])
+    params.require(:post).permit(:title, comments_attributes: [:comment, :contributor, :user_id])
   end
 end

--- a/project/app/controllers/posts_controller.rb
+++ b/project/app/controllers/posts_controller.rb
@@ -17,6 +17,7 @@ class PostsController < ApplicationController
     @comments = add_anchor_link_for_show(Comment.where(post_id: params[:id]))
     @comment = Comment.new
     @post_title = Post.find(params[:id]).title
+    @users = User.all
   end
 
   def create

--- a/project/app/views/posts/index.html.erb
+++ b/project/app/views/posts/index.html.erb
@@ -48,9 +48,17 @@
           <span class="number">
             <%= post.comments.first.serial_id %>
           </span>
-          <span class="name">
-            <%= post.comments.first.contributor.empty? ? '名無しさん' : post.comments.first.contributor %>
-          </span>
+
+          <% if !post.comments.first.user_id.nil? %>
+            <span class="name">
+              <%= @users.find(comment.user_id).name %> ◆
+            </span>
+          <% else %>
+            <span class="name">
+              <%= post.comments.first.contributor.empty? ? '名無しさん' : post.comments.first.contributor %>
+            </span>
+          <% end %>
+
           <span class="date">
             <%= post.comments.first.created_at.strftime('%Y/%m/%d %H:%M') %>
           </span>
@@ -66,9 +74,17 @@
               <span class="number">
                 <%= comment.serial_id %>
               </span>
-              <span class="name">
-                <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
-              </span>
+
+              <% if !comment.user_id.nil? %>
+                <span class="name">
+                  <%= @users.find(comment.user_id).name %> ◆
+                </span>
+              <% else %>
+                <span class="name">
+                  <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
+                </span>
+              <% end %>
+
               <span class="date">
                 <%= comment.created_at.strftime('%Y/%m/%d %H:%M') %>
               </span>

--- a/project/app/views/posts/index.html.erb
+++ b/project/app/views/posts/index.html.erb
@@ -51,7 +51,7 @@
 
           <% if !post.comments.first.user_id.nil? %>
             <span class="name">
-              <%= @users.find(comment.user_id).name %> ◆
+              <%= @users.find(post.comments.first.user_id).name %> ◆
             </span>
           <% else %>
             <span class="name">
@@ -115,11 +115,18 @@
     <br>
   </div>
   <%= form.fields_for :comments do |comment| %>
+
+  <% if current_user %>
+    <%= comment.hidden_field :contributor, :value => '' %>
+    <%= comment.hidden_field :user_id, :value => current_user.id %>
+  <% else %>
     <div class="mb-5">
       <%= comment.label "名前　　　　　　：" %>
       <%= comment.text_field :contributor, :class => 'text-field', :placeholder => '名前' %>
       <br>
     </div>
+  <% end %>
+
     <div class="mb-5">
       <%= comment.text_area :comment, :class => 'text-area-field', :placeholder => '内容' %>
     </div>

--- a/project/app/views/posts/show.html.erb
+++ b/project/app/views/posts/show.html.erb
@@ -15,9 +15,15 @@
             <%= comment.serial_id %>
           </span>
 
-          <span class="name">
-            <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
-          </span>
+          <% if !comment.user_id.nil? %>
+            <span class="name">
+              <%= @users.find(comment.user_id).name %> ◆
+            </span>
+          <% else %>
+            <span class="name">
+              <%= comment.contributor.empty? ? '名無しさん' : comment.contributor %>
+            </span>
+          <% end %>
 
           <span class="date">
             <%= comment.created_at.strftime('%Y/%m/%d %H:%M') %>
@@ -35,18 +41,25 @@
 
   <%# 投稿フォーム %>
   <div class="form-box">
-    <div class="form-header">レスを投稿する</div>
+    <h2 class="form-header">レスを投稿する</h2>
 
     <%= form_with model: @comment do |form| %>
-      <div>
-        <%= form.text_field :contributor, :class => 'one-line-post-field', :placeholder => '名前' %>
-      </div>
+      <% if current_user %>
+        <%= form.hidden_field :contributor, :value => '' %>
+      <% else %>
+        <div>
+          <%= form.text_field :contributor, :class => 'one-line-post-field', :placeholder => '名前' %>
+        </div>
+      <% end %>
 
       <div>
         <%= form.text_area :comment, :class => 'multi-line-post-field', :placeholder => 'コメント内容' %>
       </div>
 
       <%= form.hidden_field :post_id, :value => params[:id] %>
+      <% if current_user %>
+        <%= form.hidden_field :user_id, :value => current_user.id %>
+      <% end %>
 
       <button class="submit-button" type="submit" name="submit">書き込む</button>
     <% end %>


### PR DESCRIPTION
カンバンカード URL: https://www.notion.so/kotahashihama/a3376db8b5ab45a3b1953276fcd194a5

# 変更の目的・詳細

- いわゆるコテハン
- ちゃんとログインユーザーが投稿したものには `◆` が付き、直接 `◆` を名前に設定して模倣しようとした場合は `◇` と表示されます
  - 実際に `hoge ◆` とかで投稿すると分かりやすいです

## 確認用 URL

- http://localhost:3000/

# スクリーンショット

|     |
| --- |
|   <img width="592" alt="スクリーンショット 2023-01-20 午後6 04 35" src="https://user-images.githubusercontent.com/33051893/213657216-4a0e0b48-c672-4b4a-8231-f55023afbbff.png">  |
