### PR TITLE
コメントの新しい順でスレッドを並び替え

### DIFF
--- a/project/app/controllers/posts_controller.rb
+++ b/project/app/controllers/posts_controller.rb
@@ -2,7 +2,8 @@ class PostsController < ApplicationController
   def index
     Rails.logger.debug "index now"
     # スレッド一覧取得メソッド
-    @posts = add_anchor_link_for_index(Post.all)
+    posts = add_anchor_link_for_index(Post.all)
+    @posts = posts.sort_by { |post| post.comments.last.created_at }.reverse
     Rails.logger.debug @posts
     @post = Post.new
     # 下記記載がないと、.erbファイルでfields_forを使用したときに要素自体が表示されない


### PR DESCRIPTION
カンバンカード URL: https://www.notion.so/kotahashihama/db756b0996e6463d9139d975b025f457

# 変更の目的・詳細

- より5chっぽくしました

## 確認用 URL

- http://localhost:3000/

## 参考資料 URL

- 5ちゃんねるも、新しくレスが付いたスレッドが上に来るようになっている
  - https://asahi.5ch.net/newsplus/

# スクリーンショット

|   最初はこの順序  |  上から2番目のスレッドにコメントをすると   |  一覧でのスレッド表示順が変わる   |
| --- | --- | --- |
| <img width="233" alt="スクリーンショット 2023-01-22 午後9 19 46" src="https://user-images.githubusercontent.com/33051893/213915607-ea903d0e-1cdb-4785-a32b-1c69015253e5.png">    |   <img width="354" alt="スクリーンショット 2023-01-22 午後9 19 55" src="https://user-images.githubusercontent.com/33051893/213915614-2a86dda6-bb0a-485a-aa12-440bdcbe7c82.png">  |  <img width="379" alt="スクリーンショット 2023-01-22 午後9 20 09" src="https://user-images.githubusercontent.com/33051893/213915603-f0c23735-f211-407b-b825-4b9e8b560681.png">   |
