### PR TITLE
G1ちゃんねる概要部分とshowのコメント投稿フォームのcssの修正

### DIFF
--- a/project/app/assets/stylesheets/posts/show.scss
+++ b/project/app/assets/stylesheets/posts/show.scss
@@ -49,24 +49,14 @@ body {
 .form-header {
   color: #48526a;
   font-size: 16px;
+}
 
-  .form {
-    .one-line-post-field {
-      background-color: #fff;
-      padding: 6px 12px;
-      margin: 0px 0px 15px;
-    }
+.one-line-post-field {
+  width: 24em;
+  margin: 0px 0px 10px;
+}
 
-    .multi-line-post-field {
-      background-color: #fff;
-      padding: 6px 12px;
-      margin: 0px 0px 15px;
-    }
-
-    .submit-buttton {
-      background-color: #333;
-      color: #fff;
-      margin: 0px 0px 10px;
-    }
-  }
+.multi-line-post-field {
+  width: 40em;
+  height: 10em;
 }

--- a/project/app/views/posts/index.html.erb
+++ b/project/app/views/posts/index.html.erb
@@ -31,6 +31,10 @@
       <p><font size="5">・ユーザー新規登録</font></p>
       <p><font size="5">・ログイン機能</font></p>
       <p><font size="5">・なりすまし防止機能</font></p>
+      <p><font size="5">・メンション機能</font></p>
+      <p><font size="5">・コメントの新しい順でスレッド並び替え機能</font></p>
+      <p><font size="5">・マイページ機能</font></p>
+      <p><font size="5">・スレッドタイトル検索機能</font></p>
       <p><font size="5"></font></p>
 
     </div>


### PR DESCRIPTION
カンバンカード URL:

# 変更の目的・詳細

-最終発表デモ用にG1ちゃんねる概要部分の内容を修正しました。
-コメント投稿フォームはindex画面の新規スレッド作成フォームと平仄を合わせました。

## 特にレビューしてほしいところ

-修正内容に違和感ないか

## 確認用 URL

-

## 参考資料 URL

-

# スクリーンショット
![image](https://user-images.githubusercontent.com/103372110/215308056-f7e4a906-5b67-4272-8a79-3b4763d106d7.png)

![image](https://user-images.githubusercontent.com/103372110/215308066-3beb6bbd-1ac6-49cf-9e08-ccd58c00cb8b.png)
